### PR TITLE
Fix x86-64 segfault by explicitly zeroing out rax register

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -3,9 +3,9 @@ use std::arch::asm;
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn run(sp: usize, entry: usize) -> ! {
     asm! {
-        "xor rax, rax",
         "mov rsp, {sp}",
         "jmp {entry}",
+        inout("rax") 0 => _,
         sp = in(reg) sp,
         entry = in(reg) entry,
     }


### PR DESCRIPTION
I've been playing around with different compiler options in a crate using `userland-execve-rust`, and I ran into a mysterious segfault that only happened after a major change and with some very specific compilation flags. After stepping through the code in GDB, I found it was caused by the `run` function. Basically, rustc ended up picking `rax` as the register to hold the `entry` value, meaning the assembly being run was equivalent to this:

```asm
xor rax, rax
mov rsp, rbx ; `{sp}` mapped to `rbx` register
jmp rax ; `{entry}` mapped to `rax` register, which we just zeroed (segfault!)
```

The fix is to have rustc itself zero out the `rax` register, so then it knows to pick a different register for `entry`.