### PR TITLE
Add `exec_with_options` to tweak exec behavior

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::{CStr, CString},
     iter::once,
     os::unix::prelude::OsStrExt,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 fn path_to_c_string(path: &Path) -> CString {
@@ -17,11 +17,19 @@ fn path_to_c_string(path: &Path) -> CString {
     .unwrap()
 }
 
-pub fn exec(path: &Path, args: &[impl AsRef<CStr>], env: &[impl AsRef<CStr>]) -> ! {
-    let (bin_addr, bin_header, opt_interp) = crate::loader::load(path);
-    let path = path_to_c_string(path);
+pub fn exec_with_options(options: ExecOptions) -> ! {
+    let (bin_addr, bin_header, opt_interp) =
+        crate::loader::load(&options.executable, options.interpreter);
+    let path = path_to_c_string(&options.executable);
     let interp_addr = opt_interp.map(|(addr, _)| addr);
-    let sp = crate::stack::make_stack(interp_addr, bin_addr, bin_header, &path, args, env);
+    let sp = crate::stack::make_stack(
+        interp_addr,
+        bin_addr,
+        bin_header,
+        &path,
+        &options.args,
+        &options.env,
+    );
     let entry = match opt_interp {
         Some((interp_addr, interp_header)) => {
             let interp_entry: usize = interp_header.e_entry.try_into().unwrap();
@@ -33,4 +41,73 @@ pub fn exec(path: &Path, args: &[impl AsRef<CStr>], env: &[impl AsRef<CStr>]) ->
         }
     };
     unsafe { crate::run::run(sp, entry) }
+}
+
+pub fn exec(path: &Path, args: &[impl AsRef<CStr>], env: &[impl AsRef<CStr>]) -> ! {
+    let mut options = ExecOptions::new(path);
+    options.args(args);
+    options.env_pairs(env);
+
+    exec_with_options(options)
+}
+
+pub struct ExecOptions {
+    pub executable: PathBuf,
+    pub args: Vec<CString>,
+    pub env: Vec<CString>,
+    interpreter: crate::loader::Interpreter,
+}
+
+impl ExecOptions {
+    pub fn new(executable: impl AsRef<Path>) -> Self {
+        Self {
+            executable: executable.as_ref().to_owned(),
+            args: vec![],
+            env: vec![],
+            interpreter: crate::loader::Interpreter::FromHeader,
+        }
+    }
+
+    pub fn arg(&mut self, value: impl AsRef<CStr>) -> &mut Self {
+        self.args.push(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn args(&mut self, values: impl IntoIterator<Item = impl AsRef<CStr>>) -> &mut Self {
+        self.args
+            .extend(values.into_iter().map(|v| v.as_ref().to_owned()));
+        self
+    }
+
+    pub fn env(&mut self, key: impl AsRef<CStr>, value: impl AsRef<CStr>) -> &mut Self {
+        let mut pair = key.as_ref().to_bytes().to_vec();
+        pair.push(b'=');
+        pair.extend(value.as_ref().to_bytes());
+        self.env.push(CString::new(pair).unwrap());
+        self
+    }
+
+    pub fn env_pairs(&mut self, pairs: impl IntoIterator<Item = impl AsRef<CStr>>) -> &mut Self {
+        self.env
+            .extend(pairs.into_iter().map(|v| v.as_ref().to_owned()));
+        self
+    }
+
+    pub fn envs(
+        &mut self,
+        pairs: impl IntoIterator<Item = (impl AsRef<CStr>, impl AsRef<CStr>)>,
+    ) -> &mut Self {
+        for (key, value) in pairs {
+            self.env(key, value);
+        }
+        self
+    }
+
+    pub fn override_interpreter(&mut self, interpreter: Option<impl AsRef<Path>>) -> &mut Self {
+        self.interpreter = match interpreter {
+            Some(path) => crate::loader::Interpreter::Path(path.as_ref().to_owned()),
+            None => crate::loader::Interpreter::None,
+        };
+        self
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,4 @@ mod loader;
 mod run;
 mod stack;
 
-pub use exec::exec;
+pub use exec::{exec, exec_with_options, ExecOptions};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -6,15 +6,37 @@ use nix::{
     sys::mman::{mmap, MapFlags, ProtFlags},
     unistd::{sysconf, SysconfVar},
 };
-use std::{fs::File, num::NonZeroUsize, os::fd::BorrowedFd, path::Path, ptr};
+use std::{
+    fs::File,
+    num::NonZeroUsize,
+    os::fd::BorrowedFd,
+    path::{Path, PathBuf},
+    ptr,
+};
 
-pub fn load(path: &Path) -> (usize, elf::Header, Option<(usize, elf::Header)>) {
+pub enum Interpreter {
+    FromHeader,
+    None,
+    Path(PathBuf),
+}
+
+pub fn load(
+    path: &Path,
+    interpreter: Interpreter,
+) -> (usize, elf::Header, Option<(usize, elf::Header)>) {
     let file = File::open(path).unwrap();
     let bytes = std::fs::read(path).unwrap();
     let elf = Elf::parse(&bytes).unwrap();
-    let opt_interp = match elf.interpreter {
+    let interp_path: Option<&Path> = match &interpreter {
+        Interpreter::FromHeader => elf.interpreter.as_ref().map(|x| x.as_ref()),
+        Interpreter::None => None,
+        Interpreter::Path(path) => Some(&path),
+    };
+    let opt_interp = match interp_path {
         Some(interp) => {
-            let (interp_load_addr, interp_header, None) = load(interp.as_ref()) else {
+            let (interp_load_addr, interp_header, None) =
+                load(interp.as_ref(), Interpreter::FromHeader)
+            else {
                 panic!()
             };
             Some((interp_load_addr, interp_header))

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -30,12 +30,12 @@ pub fn load(
     let interp_path: Option<&Path> = match &interpreter {
         Interpreter::FromHeader => elf.interpreter.as_ref().map(|x| x.as_ref()),
         Interpreter::None => None,
-        Interpreter::Path(path) => Some(&path),
+        Interpreter::Path(path) => Some(path),
     };
     let opt_interp = match interp_path {
         Some(interp) => {
             let (interp_load_addr, interp_header, None) =
-                load(interp.as_ref(), Interpreter::FromHeader)
+                load(interp, Interpreter::FromHeader)
             else {
                 panic!()
             };

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -34,8 +34,7 @@ pub fn load(
     };
     let opt_interp = match interp_path {
         Some(interp) => {
-            let (interp_load_addr, interp_header, None) =
-                load(interp, Interpreter::FromHeader)
+            let (interp_load_addr, interp_header, None) = load(interp, Interpreter::FromHeader)
             else {
                 panic!()
             };


### PR DESCRIPTION
This PR adds a new top-level `exec_with_options` function. Rather than taking the program, args, and env, it takes a new `ExecOptions` type. This types works kind of like [`std::process::Command`](https://doc.rust-lang.org/stable/std/process/struct.Command.html): it has builder-like methods for adding args or env vars. The available methods are:

- `arg`: Append an argument
- `args`: Append multiple arguments
- `env`: Append an env var and value
- `envs`: Append multiple env vars and values
- `env_pairs`: Append multiple env vars and values. The env var name and value should be pre-formatted as a C string separated by `=`.

There's also a method for a feature that's unique to `ExecOptions`, which was my main motivation for writing it: `override_interpreter`. This allows for changing the ELF interpreter used when exec-ing. It can either be set to a custom path, or set to `None` to run the ELF without an interpreter.